### PR TITLE
Pass salt (now 16 bytes - AES256 IV size) in IV to Cipher.init().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 *.class
 *.jar
+/.classpath
+/.project


### PR DESCRIPTION
The salt was not being used in the encrypt/decrypt. It's actually pretty weird that it was half-way working before, but I checked the before/after decoding and the problem wasn't there. When I saw that the salt wasn't being used in the IV, I passed that in on both Cipher.init() calls (cutting it down to 16 bytes, which is the IV length for AES256), and it now works. Well - it successfully encrypts/decrypts; when you deliberately pass in a bad password or salt on a decrypt of a previous encryption, you get a bad padding exception.